### PR TITLE
[BugFix] ViewChild Static Flag

### DIFF
--- a/projects/swimlane/docspa-core/src/lib/modules/runtime-content/runtime-content.component.ts
+++ b/projects/swimlane/docspa-core/src/lib/modules/runtime-content/runtime-content.component.ts
@@ -10,10 +10,11 @@ import {
 export const RUNTIMECONTENT_CONFIG_TOKEN = new InjectionToken<any>( 'forRoot() configuration.' );
 
 @Component({
-  selector: 'runtime-content', // tslint:disable-line
+  selector: 'runtime-content',
   template: `
-  <div class="source" #source><ng-content></ng-content></div>
-  <div #container></div>`,
+    <div class="source" #source><ng-content></ng-content></div>
+    <div #container></div>
+  `,
   styles: [`
     runtime-content > div.source {
       display: none;
@@ -30,10 +31,10 @@ export class RuntimeContentComponent implements OnInit {
   @Input()
   template: string;
 
-  @ViewChild('container', { static: false, read: ViewContainerRef })
+  @ViewChild('container', { static: true, read: ViewContainerRef })
   container: ViewContainerRef;
 
-  @ViewChild('source', { static: false })
+  @ViewChild('source', { static: true })
   source: any;
 
   highlight: string;

--- a/src/docs/modules.md
+++ b/src/docs/modules.md
@@ -154,7 +154,7 @@ i> Various parts of DocSPA will display a page title.  By default this page titl
 | A warning
 
 [[figure | **Figure 1: Figure Title**]]
-| ![Hello](../assets/docspa_mark-only.png)
+| ![Hello](./assets/docspa_mark-only.png)
 
 [[caption | **Table 1: Table Title**]]
 | Tables        | Are           | Cool  |
@@ -458,7 +458,7 @@ Some supported docsify plugins include:
 ```
 
 ```markdown { playground }
-![](../assets/docspa_mark-only.png)
+![](./assets/docspa_mark-only.png)
 ```
 
 i> Add the `data-no-zoom` attribute to exclude an image `![](../assets/docspa_mark-only.png){ data-no-zoom="true" }`


### PR DESCRIPTION
The `ViewChild()` decorator isn't properly setting the component metadata on dev mode (Run `npm start` and check the module section on localhost:4200).

After checking the console error, the line: 
`const factory = this.createComponentFactorySync(metadata, this.context);`

is being called but the metadata property `template` is returning `undefined` if using `context` as **attribute** of `runtime-content` component.

Just check what return the metadata for this element at `modules.md` file (line 524):
```
\```markdown { playground }
<runtime-content context='{ "name": "World" }'>
Hello, {{name}}.
</runtime-content>
\```
```

Also, there are some typos on the images path on the same file, open the dev tools at the website docs and you will see the error message.

Cheers!